### PR TITLE
scrolls to bottom whenever most recent response becomes visible

### DIFF
--- a/client/src/components/chat/chat-item.tsx
+++ b/client/src/components/chat/chat-item.tsx
@@ -68,7 +68,7 @@ export function ChatItem(props: {
     answerId: string,
     answerText: string
   ) => void;
-  mostRecentResponse: boolean;
+  mostRecentMsg: boolean;
 }): JSX.Element {
   const {
     message,
@@ -78,7 +78,7 @@ export function ChatItem(props: {
     visibility,
     mentorType,
     rePlayQuestionVideo,
-    mostRecentResponse,
+    mostRecentMsg,
   } = props;
   const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
   const dispatch = useDispatch();
@@ -92,7 +92,7 @@ export function ChatItem(props: {
       : visibility && !message.isVideoInProgress;
 
   useEffect(() => {
-    if (!(isVisible && mostRecentResponse)) {
+    if (!(isVisible && mostRecentMsg)) {
       return;
     }
     animateScroll.scrollToBottom({

--- a/client/src/components/chat/chat-item.tsx
+++ b/client/src/components/chat/chat-item.tsx
@@ -4,9 +4,10 @@ Permission to use, copy, modify, and distribute this software and its documentat
 
 The full terms of this copyright and license should always be found in the root directory of this software deliverable as "license.txt" and if these terms are not found with this software, please contact the USC Stevens Center for the full license.
 */
-import React from "react";
+import React, { useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import { useDispatch, useSelector } from "react-redux";
+import { animateScroll } from "react-scroll";
 import {
   Avatar,
   ListItem,
@@ -67,6 +68,7 @@ export function ChatItem(props: {
     answerId: string,
     answerText: string
   ) => void;
+  mostRecentResponse: boolean;
 }): JSX.Element {
   const {
     message,
@@ -76,6 +78,7 @@ export function ChatItem(props: {
     visibility,
     mentorType,
     rePlayQuestionVideo,
+    mostRecentResponse
   } = props;
   const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
   const dispatch = useDispatch();
@@ -87,6 +90,15 @@ export function ChatItem(props: {
     mentorType === "CHAT"
       ? visibility
       : visibility && !message.isVideoInProgress;
+
+  useEffect(() => {
+    if(!(isVisible && mostRecentResponse)){
+      return;
+    }
+    animateScroll.scrollToBottom({
+      containerId: "chat-thread",
+    });
+  }, [isVisible]);
 
   function handleFeedbackClick(event: React.MouseEvent<HTMLDivElement>) {
     setAnchorEl(event.currentTarget);

--- a/client/src/components/chat/chat-item.tsx
+++ b/client/src/components/chat/chat-item.tsx
@@ -78,7 +78,7 @@ export function ChatItem(props: {
     visibility,
     mentorType,
     rePlayQuestionVideo,
-    mostRecentResponse
+    mostRecentResponse,
   } = props;
   const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
   const dispatch = useDispatch();
@@ -92,7 +92,7 @@ export function ChatItem(props: {
       : visibility && !message.isVideoInProgress;
 
   useEffect(() => {
-    if(!(isVisible && mostRecentResponse)){
+    if (!(isVisible && mostRecentResponse)) {
       return;
     }
     animateScroll.scrollToBottom({

--- a/client/src/components/chat/chat.tsx
+++ b/client/src/components/chat/chat.tsx
@@ -199,6 +199,7 @@ export function Chat(args: {
                 visibility={isQuestionsAnswersVisible(m.questionId)}
                 rePlayQuestionVideo={rePlayQuestionVideo}
                 mentorType={mentorType}
+                mostRecentResponse={i==(chatData.messages.length-1)}
               />
             </div>
           );

--- a/client/src/components/chat/chat.tsx
+++ b/client/src/components/chat/chat.tsx
@@ -193,7 +193,7 @@ export function Chat(args: {
                 visibility={isQuestionsAnswersVisible(m.questionId)}
                 rePlayQuestionVideo={rePlayQuestionVideo}
                 mentorType={mentorType}
-                mostRecentResponse={i == chatData.messages.length - 1}
+                mostRecentMsg={i == chatData.messages.length - 1}
               />
             </div>
           );

--- a/client/src/components/chat/chat.tsx
+++ b/client/src/components/chat/chat.tsx
@@ -199,7 +199,7 @@ export function Chat(args: {
                 visibility={isQuestionsAnswersVisible(m.questionId)}
                 rePlayQuestionVideo={rePlayQuestionVideo}
                 mentorType={mentorType}
-                mostRecentResponse={i==(chatData.messages.length-1)}
+                mostRecentResponse={i == chatData.messages.length - 1}
               />
             </div>
           );

--- a/client/src/components/chat/chat.tsx
+++ b/client/src/components/chat/chat.tsx
@@ -6,7 +6,6 @@ The full terms of this copyright and license should always be found in the root 
 */
 import React, { useEffect } from "react";
 import { useSelector } from "react-redux";
-import { animateScroll } from "react-scroll";
 import { List } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 
@@ -93,11 +92,6 @@ export function Chat(args: {
   });
 
   const chatData = useSelector<State, ChatData>((s) => s.chat);
-  useEffect(() => {
-    animateScroll.scrollToBottom({
-      containerId: "chat-thread",
-    });
-  }, [chatData.messages.length]);
 
   function isQuestionsAnswersVisible(questionId: string): boolean {
     const userPref = getQuestionVisibilityPref(questionId);


### PR DESCRIPTION
The chat would scroll down to the most recent question, but not the answer. This fixes that by scrolling whenever the most recent response becomes visible