### PR TITLE
Answer history order fix

### DIFF
--- a/client/src/store/reducer.ts
+++ b/client/src/store/reducer.ts
@@ -359,12 +359,10 @@ function onQuestionSent(state: State, action: QuestionSentAction): State {
         curQuestion: action.payload.question,
         curQuestionSource: action.payload.source,
         curQuestionUpdatedAt: new Date(Date.now()),
-        questionsAsked: Array.from(
-          new Set([
-            ...state.questionsAsked,
-            normalizeString(action.payload.question),
-          ])
-        ),
+        questionsAsked: [
+          ...state.questionsAsked,
+          normalizeString(action.payload.question),
+        ],
       },
       {
         type: QUESTION_INPUT_CHANGED,

--- a/cypress/cypress/integration/questions.spec.ts
+++ b/cypress/cypress/integration/questions.spec.ts
@@ -181,7 +181,7 @@ describe("Questions list", () => {
       .should("contain", "gray");
   });
 
-  it.only("keeps greyed out questions when switching topics if new topic also has it", () => {
+  it("keeps greyed out questions when switching topics if new topic also has it", () => {
     visitAsGuestWithDefaultSetup(cy, "/");
     cy.get("[data-cy=input-field]").type("Are you fun at parties?");
     cy.get("[data-cy=input-send]").trigger("mouseover").click();


### PR DESCRIPTION
This fix addresses a bug where if the same question was asked, the mentor answers would not always appear in order as answered. This was due to the questionCounter not updating when a duplicate question was asked because the questionsAsked array was built out of a set.